### PR TITLE
remove object inspection of last commit

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -95,9 +95,6 @@ class VariablesPanel extends DebugPanel
                     $item->getLine()
                 );
             }
-            if (is_object($item) && method_exists($item, '__debugInfo')) {
-                $item = $item->__debugInfo();
-            }
             return $item;
         });
 


### PR DESCRIPTION
f9f615c6bc55ca6cbc2e80a658da5aea8d14fe24 breaks the variable inspection

these lines breaks my ajax calls and gives 

```
You cannot serialize or unserialize PDO instances
```

on some variables
